### PR TITLE
Usability fixes for update and import

### DIFF
--- a/doniclient/osc/cli.py
+++ b/doniclient/osc/cli.py
@@ -307,7 +307,6 @@ class UpdateHardware(HardwarePatchCommand):
         )
         parse_iface.add_argument(
             "--delete",
-            metavar="index",
             help=("Specify interface to delete, by index`"),
         )
 
@@ -317,16 +316,21 @@ class UpdateHardware(HardwarePatchCommand):
         # Update Interfaces
         patch = []
         for iface in getattr(parsed_args, "add") or []:
-            patch.append({"op": "add", "path": f"/interface/-", "value": iface})
+            patch.append(
+                {"op": "add", "path": f"/properties/interfaces/-", "value": iface}
+            )
 
         for iface in getattr(parsed_args, "update") or []:
             index = iface.pop("index")
             patch.append(
-                {"op": "replace", "path": f"/interface/{index}", "value": iface}
+                {
+                    "op": "replace",
+                    "path": f"/properties/interfaces/{index}",
+                    "value": iface,
+                }
             )
-        for iface in getattr(parsed_args, "delete") or []:
-            index = iface.get("index")
-            patch.append({"op": "remove", "path": f"/interface/{index}"})
+        for index in getattr(parsed_args, "delete") or []:
+            patch.append({"op": "remove", "path": f"/properties/interfaces/{index}"})
         return patch
 
     def get_patch(self, parsed_args):

--- a/doniclient/osc/cli.py
+++ b/doniclient/osc/cli.py
@@ -273,6 +273,8 @@ class UpdateHardware(HardwarePatchCommand):
         parser.add_argument(
             "--ipmi_terminal_port", metavar="<ipmi_terminal_port>", type=int
         )
+        parser.add_argument("--deploy_kernel", metavar="<deploy_kernel>")
+        parser.add_argument("--deploy_ramdisk", metavar="<deploy_ramdisk>")
 
         subparsers = parser.add_subparsers(help="Select property to update.")
 
@@ -342,6 +344,8 @@ class UpdateHardware(HardwarePatchCommand):
             "ipmi_username": "properties/ipmi_username",
             "ipmi_password": "properties/ipmi_password",
             "ipmi_terminal_port": "properties/ipmi_terminal_port",
+            "deploy_kernel": "properties/baremetal_deploy_kernel_image",
+            "deploy_ramdisk": "properties/baremetal_deploy_ramdisk_image",
         }
         for key, val in field_map.items():
             arg = getattr(parsed_args, key, None)


### PR DESCRIPTION
fix updating "properties" for update method, and support additional properties for deploy kernel and ramdisk.

Allow bulk import to continue if devices already exist, just log error and proceed to next device.