### PR TITLE
Return 0 for successful update

### DIFF
--- a/doniclient/osc/cli.py
+++ b/doniclient/osc/cli.py
@@ -244,7 +244,7 @@ class HardwarePatchCommand(BaseParser, HardwareSerializer):
                 LOG.error(ex.response.text)
                 raise ex
             else:
-                return self.serialize_hardware(res.json(), OutputFormat.columns)
+                return 0
         else:
             LOG.info("No updates to send")
 


### PR DESCRIPTION
make sure to return 0 on success. Returning an object is interpereted
as a failure in the shell, or anything that is checking success/failure.