### PR TITLE
Allow json input of arbitrary arguments, refactor cli

### DIFF
--- a/doniclient/osc/availability.py
+++ b/doniclient/osc/availability.py
@@ -11,17 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from argparse import ArgumentTypeError
 import logging
+from argparse import ArgumentTypeError
 from typing import TYPE_CHECKING
 
-from dateutil import parser
-from dateutil import tz
+from dateutil import parser, tz
 from keystoneauth1.exceptions import HttpError
-from osc_lib.command import command
 from osc_lib import utils
+from osc_lib.command import command
 
-from doniclient.osc.cli import HardwarePatchCommand, BaseParser
+from doniclient.osc.common import HardwarePatchCommand
 
 if TYPE_CHECKING:
     from doniclient.v1.client import Client as DoniClient
@@ -62,7 +61,9 @@ class ListHardwareAvailability(command.Lister):
     def get_parser(self, prog_name):
         parser = super().get_parser(prog_name)
         parser.add_argument(
-            dest="hardware_uuid", metavar="<hardware_uuid>", help=("unique ID of hardware item")
+            dest="hardware_uuid",
+            metavar="<hardware_uuid>",
+            help=("unique ID of hardware item"),
         )
         return parser
 
@@ -81,7 +82,6 @@ class ListHardwareAvailability(command.Lister):
         return (self.columns, items_iterator)
 
 
-
 class AddHardwareAvailability(HardwarePatchCommand):
     def get_parser(self, prog_name):
         parser = super().get_parser(prog_name)
@@ -96,7 +96,7 @@ class AddHardwareAvailability(HardwarePatchCommand):
                 "value": {
                     "start": parsed_args.start,
                     "end": parsed_args.end,
-                }
+                },
             }
         ]
 
@@ -118,11 +118,13 @@ class UpdateHardwareAvailability(HardwarePatchCommand):
         for field in ["start", "end"]:
             value = getattr(parsed_args, field)
             if value:
-                patch.append({
-                    "op": "replace",
-                    "path": f"/availability/{parsed_args.window_uuid}/{field}",
-                    "value": value
-                })
+                patch.append(
+                    {
+                        "op": "replace",
+                        "path": f"/availability/{parsed_args.window_uuid}/{field}",
+                        "value": value,
+                    }
+                )
 
         return patch
 

--- a/doniclient/osc/cli.py
+++ b/doniclient/osc/cli.py
@@ -1,73 +1,30 @@
 """Implements Doni command line interface."""
 
+import argparse
 import json
 import logging
-from argparse import ArgumentTypeError, FileType
-from sys import stdin
-from typing import DefaultDict, List
+from argparse import FileType, Namespace
 
-import yaml
-from cliff.columns import FormattableColumn
 from keystoneauth1.exceptions import Conflict, HttpError
 from keystoneauth1.exceptions.http import BadRequest
-from osc_lib import utils
-from osc_lib.cli import parseractions
 from osc_lib.command import command
 
+from doniclient.osc.common import (
+    BaseParser,
+    GroupedAction,
+    HardwarePatchCommand,
+    HardwareSerializer,
+    OutputFormat,
+    SingleParser,
+)
+
 LOG = logging.getLogger(__name__)  # Get the logger of this module
-
-
-class DoniClientError(BaseException):
-    """Base Error Class for Doni Client."""
-
-
-class OutputFormat:
-    columns = (
-        "uuid",
-        "name",
-        "project_id",
-        "hardware_type",
-        "properties",
-    )
-
-
-class YamlColumn(FormattableColumn):
-    def human_readable(self):
-        return yaml.dump(self._value)
-
-
-class HardwareSerializer(object):
-    def serialize_hardware(self, hw_dict: "dict", columns: "list[str]"):
-        return utils.get_dict_properties(
-            hw_dict,
-            columns,
-            formatters={
-                "properties": YamlColumn,
-                "workers": YamlColumn,
-            },
-        )
-
-
-class BaseParser(command.Command):
-
-    require_hardware = False
-    iface_required_keys = ["mac_address"]
-    iface_optional_keys = ["name", "switch_info", "switch_port_id", "switch_id"]
-
-    def get_parser(self, prog_name):
-        parser = super().get_parser(prog_name)
-        parser.add_argument("-d", "--dry-run", "--dry_run", action="store_true")
-        if self.require_hardware:
-            parser.add_argument(
-                dest="uuid", metavar="<uuid>", help=("unique ID of hardware item")
-            )
-        return parser
 
 
 class ListHardware(command.Lister, HardwareSerializer):
     """List all hardware in the Doni database."""
 
-    columns = OutputFormat.columns
+    columns = list(OutputFormat.columns)
 
     def get_parser(self, prog_name):
         parser = super().get_parser(prog_name)
@@ -90,15 +47,17 @@ class ListHardware(command.Lister, HardwareSerializer):
             LOG.error(ex.response.text)
             raise ex
 
-        data_iterator = (self.serialize_hardware(s, self.columns) for s in data)
-        return (self.columns, data_iterator)
+        return (
+            self.columns,
+            (self.serialize_hardware(item, self.columns) for item in data),
+        )
 
 
-class GetHardware(BaseParser, command.ShowOne, HardwareSerializer):
+class GetHardware(SingleParser, command.ShowOne, HardwareSerializer):
     """List specific hardware item in Doni."""
 
-    require_hardware = True
-    columns = (*OutputFormat.columns, "workers")
+    columns = list(OutputFormat.columns)
+    columns.append("workers")
 
     def take_action(self, parsed_args):
         """List all hw items in Doni."""
@@ -115,246 +74,226 @@ class GetHardware(BaseParser, command.ShowOne, HardwareSerializer):
         )
 
 
-class DeleteHardware(BaseParser):
+class DeleteHardware(SingleParser):
     """Delete specific hardware item in Doni."""
 
-    require_hardware = True
-
     def take_action(self, parsed_args):
         hw_client = self.app.client_manager.inventory
         try:
-            result = hw_client.delete(parsed_args.uuid)
+            hw_client.delete(parsed_args.uuid)
         except HttpError as ex:
             LOG.error(ex.response.text)
             raise ex
 
-        return result.text
 
-
-class SyncHardware(BaseParser):
+class SyncHardware(SingleParser):
     """Sync specific hardware item in Doni."""
 
-    require_hardware = True
-
     def take_action(self, parsed_args):
         hw_client = self.app.client_manager.inventory
         try:
-            result = hw_client.sync(parsed_args.uuid)
+            hw_client.sync(parsed_args.uuid)
         except HttpError as ex:
             LOG.error(ex.response.text)
             raise ex
 
-        return result.text
 
-
-class CreateHardware(BaseParser, HardwareSerializer):
-    """Create a Hardware Object in Doni."""
-
+class CreateOrUpdateParser(BaseParser):
     def get_parser(self, prog_name):
         parser = super().get_parser(prog_name)
         parser.add_argument(
             "--name",
-            metavar="<name>",
             help=(
                 "Name of the hardware object. Best practice is to use a "
                 "universally unique identifier, such has serial number or chassis ID. "
                 "This will aid in disambiguating systems."
             ),
-            required=True,
         )
         parser.add_argument(
             "--hardware_type",
-            metavar="<hardware_type>",
-            help=("hardware_type of item"),
             default="baremetal",
-        )
-        parser.add_argument("--mgmt_addr", metavar="<mgmt_addr>", required=True)
-        parser.add_argument("--ipmi_username", metavar="<ipmi_username>")
-        parser.add_argument("--ipmi_password", metavar="<ipmi_password>")
-        parser.add_argument(
-            "--ipmi_terminal_port", metavar="<ipmi_terminal_port>", type=int
+            help=("hardware_type of item"),
         )
 
         parser.add_argument(
-            "--interface",
-            required_keys=self.iface_required_keys,
-            optional_keys=self.iface_optional_keys,
-            action=parseractions.MultiKeyValueAction,
-            help=(
-                "Specify once per interface, in the form:"
-                "`--interface key1=value1, key2=value2, ...`"
-                f"\nRequired Keys are {self.iface_required_keys}"
-                f"\nOptional Keys are {self.iface_optional_keys}"
-            ),
-            required=True,
+            "--properties",
+            default={},
+            type=json.loads,
+            dest="properties",
+            help="specify node properties directly as json dict",
         )
+
+        properties = parser.add_argument_group("properties")
+
+        properties.add_argument(
+            "--mgmt_addr",
+            metavar="<mgmt_addr>",
+            dest="properties.mgmt_addr",
+            action=GroupedAction,
+        )
+        properties.add_argument(
+            "--ipmi_username",
+            metavar="<ipmi_username>",
+            dest="properties.ipmi_username",
+            action=GroupedAction,
+        )
+        properties.add_argument(
+            "--ipmi_password",
+            metavar="<ipmi_password>",
+            dest="properties.ipmi_password",
+            action=GroupedAction,
+        )
+        properties.add_argument(
+            "--ipmi_terminal_port",
+            metavar="<ipmi_terminal_port>",
+            dest="properties.ipmi_terminal_port",
+            action=GroupedAction,
+            type=int,
+        )
+        properties.add_argument(
+            "--deploy_kernel",
+            metavar="<deploy_kernel>",
+            dest="properties.baremetal_deploy_kernel_image",
+            action=GroupedAction,
+        )
+        properties.add_argument(
+            "--deploy_ramdisk",
+            metavar="<deploy_ramdisk>",
+            dest="properties.baremetal_deploy_ramdisk_image",
+            action=GroupedAction,
+        )
+        properties.add_argument(
+            "--ironic_driver",
+            metavar="<ironic_driver>",
+            dest="properties.baremetal_driver",
+            action=GroupedAction,
+        )
+        properties.add_argument(
+            "--resource_class",
+            metavar="<resource_class>",
+            default="baremetal",
+            dest="properties.baremetal_resource_class",
+            action=GroupedAction,
+        )
+        properties.add_argument(
+            "--cpu_arch",
+            metavar="<cpu_arch>",
+            default="x86_64",
+            dest="properties.cpu_arch",
+            action=GroupedAction,
+        )
+        properties.add_argument(
+            "--blazar_node_type",
+            metavar="<blazar_node_type>",
+            dest="properties.node_type",
+            action=GroupedAction,
+        )
+        properties.add_argument(
+            "--blazar_su_factor",
+            metavar="<blazar_su_factor>",
+            dest="properties.su_factor",
+            type=float,
+            default=1.0,
+            action=GroupedAction,
+        )
+        properties.add_argument(
+            "--placement",
+            metavar="<placement>",
+            dest="properties.placement",
+            action=GroupedAction,
+            type=json.loads,
+        )
+        properties.add_argument(
+            "--capabilities",
+            metavar="<capabilities>",
+            dest="properties.baremetal_capabilities",
+            action=GroupedAction,
+            type=json.loads,
+        )
+
+        properties.add_argument(
+            "--interfaces",
+            default={},
+            dest="properties.interfaces",
+            type=json.loads,
+            help="specify interfaces directly as json dict",
+            action=GroupedAction,
+        )
+
+        # interfaces = parser.add_argument_group("interfaces")
+
+        # interfaces.add_argument("--iface_mac")
+        # interfaces.add_argument("--iface_name")
+        # interfaces.add_argument("--switch_id")
+        # interfaces.add_argument("--switch_info")
+        # interfaces.add_argument("--switch_port_id")
+
         return parser
 
-    def take_action(self, parsed_args):
+
+class CreateHardware(CreateOrUpdateParser):
+    """Create a Hardware Object in Doni."""
+
+    def get_parser(self, prog_name):
+        return super().get_parser(prog_name)
+
+    def take_action(self, parsed_args: Namespace):
         """Create new HW item."""
+        # Call superclass action to parse input json
+        super().take_action(parsed_args)
+
         hw_client = self.app.client_manager.inventory
 
         body = {
             "name": parsed_args.name,
             "hardware_type": parsed_args.hardware_type,
-            "properties": {},
+            "properties": parsed_args.properties,
         }
-        body["properties"]["management_address"] = parsed_args.mgmt_addr
-
-        for arg in ["ipmi_username", "ipmi_password", "ipmi_terminal_port"]:
-            value = getattr(parsed_args, arg)
-            if value:
-                body["properties"][arg] = value
-        body["properties"]["interfaces"] = parsed_args.interface
 
         if parsed_args.dry_run:
             LOG.warn(parsed_args)
             LOG.warn(body)
-        else:
-            try:
-                data = hw_client.create(body)
-            except HttpError as ex:
-                LOG.error(ex.response.text)
-                raise ex
+            return
 
-            return self.serialize_hardware(data, OutputFormat.columns)
-
-
-class HardwarePatchCommand(BaseParser, HardwareSerializer):
-    require_hardware = True
-
-    def get_patch(self, parsed_args):
-        return []
-
-    def take_action(self, parsed_args):
-        hw_client = self.app.client_manager.inventory
-        hw_uuid = parsed_args.uuid
-
-        patch = self.get_patch(parsed_args)
-
-        if parsed_args.dry_run:
-            LOG.info(patch)
-            return None
-
-        if patch:
-            try:
-                LOG.debug(f"PATCH_BODY:{patch}")
-                res = hw_client.update(hw_uuid, patch)
-            except HttpError as ex:
-                LOG.error(ex.response.text)
-                raise ex
-            else:
-                return self.serialize_hardware(res.json(), OutputFormat.columns)
-        else:
-            LOG.info("No updates to send")
+        try:
+            data = hw_client.create(body)
+        except HttpError as ex:
+            LOG.error(ex.response.text)
+            raise ex
 
 
-class UpdateHardware(HardwarePatchCommand):
+class UpdateHardware(CreateOrUpdateParser, HardwarePatchCommand):
+    """Update properties of existing hardware item."""
+
     def get_parser(self, prog_name):
         parser = super().get_parser(prog_name)
 
-        parser.add_argument(
-            "--name",
-            metavar="<name>",
-            help=(
-                "Name of the hardware object. Best practice is to use a "
-                "universally unique identifier, such has serial number or chassis ID. "
-                "This will aid in disambiguating systems."
-            ),
-        )
-        parser.add_argument(
-            "--hardware_type",
-            metavar="<hardware_type>",
-            help=("hardware_type of item"),
-        )
-        parser.add_argument("--mgmt_addr", metavar="<mgmt_addr>")
-        parser.add_argument("--ipmi_username", metavar="<ipmi_username>")
-        parser.add_argument("--ipmi_password", metavar="<ipmi_password>")
-        parser.add_argument(
-            "--ipmi_terminal_port", metavar="<ipmi_terminal_port>", type=int
-        )
-        parser.add_argument("--deploy_kernel", metavar="<deploy_kernel>")
-        parser.add_argument("--deploy_ramdisk", metavar="<deploy_ramdisk>")
-
-        subparsers = parser.add_subparsers(help="Select property to update.")
-
-        parse_iface = subparsers.add_parser("interface")
-        parse_iface.set_defaults(func=self._handle_ifaces)
-
-        parse_iface.add_argument(
-            "--add",
-            required_keys=self.iface_required_keys,
-            optional_keys=self.iface_optional_keys,
-            action=parseractions.MultiKeyValueAction,
-            help=(
-                "Specify once per interface, in the form:"
-                "`--interface key1=value1, key2=value2, ...`"
-                f"\nRequired Keys are {self.iface_required_keys}"
-                f"\nOptional Keys are {self.iface_optional_keys}"
-            ),
-        )
-        update_keys = ["index"]
-        update_keys.extend(self.iface_required_keys)
-        parse_iface.add_argument(
-            "--update",
-            required_keys=update_keys,
-            optional_keys=self.iface_optional_keys,
-            action=parseractions.MultiKeyValueAction,
-            help=(
-                "Specify once per interface, in the form:"
-                "`--interface key1=value1, key2=value2, ...`"
-                f"\nRequired Keys are {update_keys}"
-                f"\nOptional Keys are {self.iface_optional_keys}"
-            ),
-        )
-        parse_iface.add_argument(
-            "--delete",
-            help=("Specify interface to delete, by index`"),
-        )
+        args_to_default = ("name", "hardware_type", "properties")
+        # Unset all defaults to avoid accidental changes
+        for arg in parser._get_optional_actions():
+            if arg.dest in args_to_default:
+                arg.default = argparse.SUPPRESS
 
         return parser
 
-    def _handle_ifaces(self, parsed_args):
-        # Update Interfaces
-        patch = []
-        for iface in getattr(parsed_args, "add") or []:
-            patch.append(
-                {"op": "add", "path": f"/properties/interfaces/-", "value": iface}
-            )
-
-        for iface in getattr(parsed_args, "update") or []:
-            index = iface.pop("index")
-            patch.append(
-                {
-                    "op": "replace",
-                    "path": f"/properties/interfaces/{index}",
-                    "value": iface,
-                }
-            )
-        for index in getattr(parsed_args, "delete") or []:
-            patch.append({"op": "remove", "path": f"/properties/interfaces/{index}"})
-        return patch
-
     def get_patch(self, parsed_args):
         patch = []
+
         field_map = {
             "name": "name",
             "hardware_type": "hardware_type",
-            "management_address": "properties/management_address",
-            "ipmi_username": "properties/ipmi_username",
-            "ipmi_password": "properties/ipmi_password",
-            "ipmi_terminal_port": "properties/ipmi_terminal_port",
-            "deploy_kernel": "properties/baremetal_deploy_kernel_image",
-            "deploy_ramdisk": "properties/baremetal_deploy_ramdisk_image",
         }
+
         for key, val in field_map.items():
             arg = getattr(parsed_args, key, None)
             if arg:
                 patch.append({"op": "add", "path": f"/{val}", "value": arg})
 
-        subparser = getattr(parsed_args, "func", None)
-        if subparser:
-            patch.extend(subparser(parsed_args))
+        try:
+            for key, val in parsed_args.properties.items():
+                patch.append({"op": "add", "path": f"/properties/{key}", "value": val})
+        except AttributeError:
+            pass
 
         return patch
 

--- a/doniclient/osc/common.py
+++ b/doniclient/osc/common.py
@@ -1,0 +1,128 @@
+import argparse
+import json
+import logging
+from argparse import FileType, Namespace
+
+import yaml
+from cliff.columns import FormattableColumn
+from keystoneauth1.exceptions import HttpError
+from osc_lib import utils as osc_utils
+from osc_lib.command import command
+
+LOG = logging.getLogger(__name__)  # Get the logger of this module
+
+
+class OutputFormat:
+    columns = (
+        "uuid",
+        "name",
+        "project_id",
+        "hardware_type",
+        "properties",
+    )
+
+
+class YamlColumn(FormattableColumn):
+    def human_readable(self):
+        return yaml.dump(self._value)
+
+
+class HardwareSerializer(object):
+    def serialize_hardware(self, hw_dict: "dict", columns: "list[str]"):
+        return osc_utils.get_dict_properties(
+            hw_dict,
+            columns,
+            formatters={
+                "properties": YamlColumn,
+                "workers": YamlColumn,
+            },
+        )
+
+
+class GroupedAction(argparse.Action):
+    """Set property based on dest.key."""
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        group, dest = self.dest.split(".", 2)
+
+        try:
+            group_dict = getattr(namespace, group)
+        except AttributeError:
+            group_dict = {}
+        group_dict.update({dest: values})
+        setattr(namespace, group, group_dict)
+
+
+class BaseParser(command.Command):
+    """Base Parser for use with Doni commands.
+
+    Behavior is to take arguments in the following forms, with later ones
+    overriding earlier.
+    - argparse "default" values
+    - cli args
+    - serialized json string (or json file for bulk)
+    """
+
+    def get_parser(self, prog_name):
+        parser = super().get_parser(prog_name)
+        parser.add_argument("-d", "--dry-run", "--dry_run", action="store_true")
+        parser.add_argument(
+            "--json",
+            default={},
+            type=json.loads,
+            help="Take args as json string. Values are overridden by other args.",
+        )
+        return parser
+
+    def take_action(self, parsed_args: Namespace):
+        """This allows setting arbitrary args via json input."""
+
+        # Get dict of args without json string
+        args_dict = vars(parsed_args)
+        try:
+            # convert json input to dict, remove from namespace
+            json_dict = args_dict.get("json", {})
+            # override parsed_args with json values
+            args_dict.update(json_dict)
+        except AttributeError:
+            pass
+
+
+class SingleParser(BaseParser):
+    """Base parser for commands operating on unique item."""
+
+    def get_parser(self, prog_name):
+        parser = super().get_parser(prog_name)
+        parser.add_argument(
+            dest="uuid",
+            metavar="<uuid>",
+            help=("unique ID of hardware item"),
+        )
+        return parser
+
+
+class HardwarePatchCommand(SingleParser, HardwareSerializer):
+    def get_patch(self, parsed_args):
+        return []
+
+    def take_action(self, parsed_args):
+        hw_client = self.app.client_manager.inventory
+        hw_uuid = parsed_args.uuid
+
+        patch = self.get_patch(parsed_args)
+
+        if parsed_args.dry_run:
+            LOG.info(patch)
+            return None
+
+        if patch:
+            try:
+                LOG.debug(f"PATCH_BODY:{patch}")
+                res = hw_client.update(hw_uuid, patch)
+            except HttpError as ex:
+                LOG.error(ex.response.text)
+                raise ex
+            else:
+                return self.serialize_hardware(res.json(), list(OutputFormat.columns))
+        else:
+            LOG.info("No updates to send")


### PR DESCRIPTION
Begin refactor of cli into a common module.
Main addition of ability to pass input to any command via --json flag, allows for edge cases without a manual flag added.

Parsers now take input in order of:
- argparse defaults
- argparse optional arguments
- json input

with items lower down this list overriding ones above.

The "update" method now inherits the same arguments as "create", but explicitly unsets all defaults to prevent sending unintended patches.