### PR TITLE
add unittests for hardware update params

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,14 @@
+{
+    "python.testing.unittestArgs": [
+        "-v",
+        "-s",
+        "./doniclient",
+        "-p",
+        "*test.py"
+    ],
+    "python.testing.pytestEnabled": true,
+    "python.testing.unittestEnabled": false,
+    "python.testing.pytestArgs": [
+        "doniclient"
+    ]
+}


### PR DESCRIPTION
use metaclass to generate tests for list of update params. this is compatible with unittest's test discovery, and allows them to be run in parallel.