### PR TITLE
Set and delete using name of HW

### DIFF
--- a/doniclient/osc/cli.py
+++ b/doniclient/osc/cli.py
@@ -163,7 +163,7 @@ class CreateOrUpdateParser(BaseParser):
             parser,
             "baremetal",
             {
-                "mgmt_addr": PropertyFlag("mgmt_addr", str, None),
+                "management_address": PropertyFlag("management_address", str, None),
                 "ipmi_username": PropertyFlag("ipmi_username", str, None),
                 "ipmi_password": PropertyFlag("ipmi_password", str, None),
                 "ipmi_terminal_port": PropertyFlag("ipmi_terminal_port", int, None),

--- a/doniclient/osc/cli.py
+++ b/doniclient/osc/cli.py
@@ -221,7 +221,7 @@ class CreateHardware(CreateOrUpdateParser):
         """Create new HW item."""
         # Call superclass action to parse input json
         super().take_action(parsed_args)
-
+    
         hw_client = self.app.client_manager.inventory
 
         hw_type = parsed_args.hardware_type

--- a/doniclient/osc/cli.py
+++ b/doniclient/osc/cli.py
@@ -56,17 +56,6 @@ class ListHardware(BaseParser, command.Lister):
             data = hw_client.export()
         else:
             data = hw_client.list()
-        
-        worker_types = set([j['worker_type'] for i in data for j in i['workers']])
-        print(worker_types)
-        print(labels)
-        pep = (
-            oscutils.get_dict_properties(
-                    s, columns, formatters={"Properties": oscutils.format_dict}
-            )
-            for s in data
-        )
-        print(i for i in pep)
         return (
             labels,
             (

--- a/doniclient/tests/osc/test_hardware.py
+++ b/doniclient/tests/osc/test_hardware.py
@@ -6,9 +6,9 @@ FAKE_HARDWARE_UUID = hardware_fakes.hardware_uuid
 UPDATE_PARAMS = [
     (
         "baremetal",
-        "--mgmt_addr",
-        "mgmt_addr",
-        "/properties/mgmt_addr",
+        "--management_address",
+        "management_address",
+        "/properties/management_address",
         "fake-mgmt_addr",
     ),
     (

--- a/doniclient/v1/client.py
+++ b/doniclient/v1/client.py
@@ -50,26 +50,11 @@ class Client(object):
         except json.JSONDecodeError:
             return resp
 
-    def delete(self, name_or_uuid):
-        hardware_list = self.list()
-        matching_hardware = [h for h in hardware_list if h['name'] == name_or_uuid]
-        hardware_uuid = name_or_uuid
-        if matching_hardware:
-            hardware_uuid = matching_hardware[0]['uuid']
-        return self.adapter.delete(f"/v1/hardware/{hardware_uuid}/")
-        
+    def delete(self, uuid):
+        return self.adapter.delete(f"/v1/hardware/{uuid}/")
 
     def sync(self, uuid):
         return self.adapter.post(f"/v1/hardware/{uuid}/sync")
 
-    def update(self, name_or_uuid, json):
-        hardware_list = self.list()
-        matching_hardware = [h for h in hardware_list if h['name'] == name_or_uuid]
-        hardware_uuid = name_or_uuid
-        if matching_hardware:
-            hardware_uuid = matching_hardware[0]['uuid']
-        resp = self.adapter.patch(f"/v1/hardware/{hardware_uuid}/", json=json)
-        try:
-            return resp.json()
-        except json.JSONDecodeError:
-            return resp
+    def update(self, uuid, json):
+        return self.adapter.patch(f"/v1/hardware/{uuid}/", json=json).json()

--- a/doniclient/v1/client.py
+++ b/doniclient/v1/client.py
@@ -50,11 +50,29 @@ class Client(object):
         except json.JSONDecodeError:
             return resp
 
-    def delete(self, uuid):
-        return self.adapter.delete(f"/v1/hardware/{uuid}/")
+    def delete(self, name_or_uuid):
+        hardware_list = self.list()
+        matching_hardware = [h for h in hardware_list if h['name'] == name_or_uuid]
+
+        if matching_hardware:
+            hardware_uuid = matching_hardware[0]['uuid']
+            return self.adapter.delete(f"/v1/hardware/{hardware_uuid}/")
+        else:
+            raise ValueError("Hardware not found")
 
     def sync(self, uuid):
         return self.adapter.post(f"/v1/hardware/{uuid}/sync")
 
-    def update(self, uuid, json):
-        return self.adapter.patch(f"/v1/hardware/{uuid}/", json=json).json()
+    def update(self, name_or_uuid, json):
+        hardware_list = self.list()
+        matching_hardware = [h for h in hardware_list if h['name'] == name_or_uuid]
+
+        if matching_hardware:
+            hardware_uuid = matching_hardware[0]['uuid']
+            resp = self.adapter.patch(f"/v1/hardware/{hardware_uuid}/", json=json)
+            try:
+                return resp.json()
+            except json.JSONDecodeError:
+                return resp
+        else:
+            raise ValueError("Hardware not found")

--- a/doniclient/v1/client.py
+++ b/doniclient/v1/client.py
@@ -53,12 +53,11 @@ class Client(object):
     def delete(self, name_or_uuid):
         hardware_list = self.list()
         matching_hardware = [h for h in hardware_list if h['name'] == name_or_uuid]
-
+        hardware_uuid = name_or_uuid
         if matching_hardware:
             hardware_uuid = matching_hardware[0]['uuid']
-            return self.adapter.delete(f"/v1/hardware/{hardware_uuid}/")
-        else:
-            raise ValueError("Hardware not found")
+        return self.adapter.delete(f"/v1/hardware/{hardware_uuid}/")
+        
 
     def sync(self, uuid):
         return self.adapter.post(f"/v1/hardware/{uuid}/sync")
@@ -66,13 +65,11 @@ class Client(object):
     def update(self, name_or_uuid, json):
         hardware_list = self.list()
         matching_hardware = [h for h in hardware_list if h['name'] == name_or_uuid]
-
+        hardware_uuid = name_or_uuid
         if matching_hardware:
             hardware_uuid = matching_hardware[0]['uuid']
-            resp = self.adapter.patch(f"/v1/hardware/{hardware_uuid}/", json=json)
-            try:
-                return resp.json()
-            except json.JSONDecodeError:
-                return resp
-        else:
-            raise ValueError("Hardware not found")
+        resp = self.adapter.patch(f"/v1/hardware/{hardware_uuid}/", json=json)
+        try:
+            return resp.json()
+        except json.JSONDecodeError:
+            return resp


### PR DESCRIPTION
Rename command line flag `--mgmt_addr` to `--management_address`
`set` and `delete` uses `list` to work with name_or_uuid in the command line