### PR TITLE
Rename the command line flag mgmt_addr to management_address

### DIFF
--- a/doniclient/osc/cli.py
+++ b/doniclient/osc/cli.py
@@ -163,7 +163,7 @@ class CreateOrUpdateParser(BaseParser):
             parser,
             "baremetal",
             {
-                "mgmt_addr": PropertyFlag("mgmt_addr", str, None),
+                "management_address": PropertyFlag("management_address", str, None),
                 "ipmi_username": PropertyFlag("ipmi_username", str, None),
                 "ipmi_password": PropertyFlag("ipmi_password", str, None),
                 "ipmi_terminal_port": PropertyFlag("ipmi_terminal_port", int, None),

--- a/doniclient/tests/osc/test_hardware.py
+++ b/doniclient/tests/osc/test_hardware.py
@@ -6,9 +6,9 @@ FAKE_HARDWARE_UUID = hardware_fakes.hardware_uuid
 UPDATE_PARAMS = [
     (
         "baremetal",
-        "--mgmt_addr",
-        "mgmt_addr",
-        "/properties/mgmt_addr",
+        "--management_address",
+        "management_address",
+        "/properties/management_address",
         "fake-mgmt_addr",
     ),
     (


### PR DESCRIPTION
The error:
When request is sent with `mgmt_addr` as used in command line arg
> RESP BODY: {"error":"Schema error for hardware_params: 'management_address' is a required property (in '[0].properties.properties')"}
> Request returned failure status: 400 {"error":"Schema error for hardware_params: 'management_address' is a required property (in '[0].properties.properties')"}

when used with flag `--management_address` 
> openstack hardware create: error: unrecognized arguments: --management_address